### PR TITLE
Backslash for paths instead of forward for constants in build_h.jl

### DIFF
--- a/base/Makefile
+++ b/base/Makefile
@@ -56,12 +56,21 @@ endif
 	@echo "const libllvm_version_string = \"$$($(LLVM_CONFIG_HOST) --version)\"" >> $@
 	@echo "const VERSION_STRING = \"$(JULIA_VERSION)\"" >> $@
 	@echo "const TAGGED_RELEASE_BANNER = \"$(TAGGED_RELEASE_BANNER)\"" >> $@
+ifeq ($(OS),WINNT)
+	@echo 'const SYSCONFDIR = "$(subst /,\\\\,$(sysconfdir_rel))"' >> $@
+	@echo 'const DATAROOTDIR = "$(subst /,\\\\,$(datarootdir_rel))"' >> $@
+	@echo 'const DOCDIR = "$(subst /,\\\\,$(docdir_rel))"' >> $@
+	@echo 'const LIBDIR = "$(subst /,\\\\,$(libdir_rel))"' >> $@
+	@echo 'const PRIVATE_LIBDIR = "$(subst /,\\\\,$(private_libdir_rel))"' >> $@
+	@echo 'const INCLUDEDIR = "$(subst /,\\\\,$(includedir_rel))"' >> $@
+else
 	@echo "const SYSCONFDIR = \"$(sysconfdir_rel)\"" >> $@
 	@echo "const DATAROOTDIR = \"$(datarootdir_rel)\"" >> $@
 	@echo "const DOCDIR = \"$(docdir_rel)\"" >> $@
 	@echo "const LIBDIR = \"$(libdir_rel)\"" >> $@
 	@echo "const PRIVATE_LIBDIR = \"$(private_libdir_rel)\"" >> $@
 	@echo "const INCLUDEDIR = \"$(includedir_rel)\"" >> $@
+endif
 
 	@# This to ensure that we always rebuild this file, but only when it is modified do we touch build_h.jl,
 	@# ensuring we rebuild the system image as infrequently as possible

--- a/test/osutils.jl
+++ b/test/osutils.jl
@@ -26,3 +26,13 @@ end
 @test (@static false && 1) === false
 @test (@static true || 1) === true
 @test (@static false || 1) === 1
+
+# test that path variables use proper path deliminter on windows
+if is_windows()
+    @test !contains(Base.SYSCONFDIR, "/")
+    @test !contains(Base.DATAROOTDIR, "/")
+    @test !contains(Base.DOCDIR, "/")
+    @test !contains(Base.LIBDIR, "/")
+    @test !contains(Base.PRIVATE_LIBDIR, "/")
+    @test !contains(Base.INCLUDEDIR, "/")
+end

--- a/test/osutils.jl
+++ b/test/osutils.jl
@@ -27,7 +27,7 @@ end
 @test (@static true || 1) === true
 @test (@static false || 1) === 1
 
-# test that path variables use proper path deliminter on windows
+# test that path variables use correct path delimiters on windows
 if is_windows()
     @test !contains(Base.SYSCONFDIR, "/")
     @test !contains(Base.DATAROOTDIR, "/")


### PR DESCRIPTION
my try at fixing
(wasn't able to test locally on windows, so will rely on appveyor here)